### PR TITLE
xcrypt: fix building on 32bit platforms

### DIFF
--- a/xcrypt/src/lib.rs
+++ b/xcrypt/src/lib.rs
@@ -103,6 +103,12 @@ pub fn crypt_gensalt(
         )
     })?;
 
+    let count = count.try_into().map_err(|_| {
+        Error::invalid_argument(
+            "count argument out of range",
+        )
+    })?;
+
     let c_settings = unsafe {
         let settings_ptr = xcrypt_sys::crypt_gensalt_rn(
             c_prefix_ptr,


### PR DESCRIPTION
The xcrypt_sys function signature takes c_ulong
which varies in length depending on platform.

This fixes build error that presented itself as:

> error[E0308]: mismatched types
>    --> xcrypt/src/lib.rs:109:13
>     |
> 107 |         let settings_ptr = xcrypt_sys::crypt_gensalt_rn(
>     |                            ---------------------------- arguments to this function are incorrect
> 108 |             c_prefix_ptr,
> 109 |             count,
>     |             ^^^^^ expected `u32`, found `u64`
>     |
> note: function defined here
>    --> /build/source/target/arm-unknown-linux-gnueabihf/release/build/xcrypt-sys-0780c2fe6f4bf79a/out/bindings.rs:3:5123
>     |
> 3   | ... mut :: std :: os :: raw :: c_char ; } extern "C" { pub fn crypt_gensalt_rn (__prefix : * const :: std :: os :: raw :: c_char , __coun...
>     |                                                               ^^^^^^^^^^^^^^^^
> help: you can convert a `u64` to a `u32` and panic if the converted value doesn't fit
>     |
> 109 |             count.try_into().unwrap(),
>     |                  ++++++++++++++++++++
>
> For more information about this error, try `rustc --explain E0308`.